### PR TITLE
Add functionality for note css styling.

### DIFF
--- a/takenote/note.py
+++ b/takenote/note.py
@@ -1,8 +1,36 @@
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from string import Template
+from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, Union
 from uuid import uuid4
 
 from takenote.ui.note.note_pin_mode import NotePinMode
 from takenote.utils import Position, Size
+
+
+class NoteStyle(NamedTuple):
+
+    background_color: str
+    font_family: str
+    font_size: str
+    text_color: str
+
+    def fill_css_template(self, filepath: str) -> str:
+        with open(filepath, "r") as file:
+            css_template = Template(file.read())
+
+        css_string = css_template.substitute(**self._asdict())
+        return css_string
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self._asdict()
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "NoteStyle":
+        return cls(
+            background_color=data["background_color"],
+            font_family=data["font_family"],
+            font_size=data["font_size"],
+            text_color=data["text_color"],
+        )
 
 
 class Note:
@@ -12,15 +40,17 @@ class Note:
             uuid: str,
             content: str,
             pinmode: NotePinMode,
+            style: NoteStyle,
             position: Union[Position, Tuple[Any, Any]] = None,
             size: Union[Size, Tuple[Any, Any]] = None,
-            save_required: bool = False, 
+            save_required: bool = False,
     ):
         self._uuid = uuid
         self._content = content
         self._pinmode = pinmode
         self._position = position
         self._size = size
+        self._style = style
 
         self._save_required = save_required
         self._on_save_cb: Optional[Callable] = None
@@ -36,6 +66,10 @@ class Note:
     @property
     def pinmode(self) -> NotePinMode:
         return self._pinmode
+
+    @property
+    def style(self) -> NoteStyle:
+        return self._style
 
     @property
     def position(self) -> Optional[Position]:
@@ -58,6 +92,11 @@ class Note:
     def pinmode(self, value: NotePinMode):
         self._save_required |= self._pinmode != value
         self._pinmode = value
+
+    @style.setter
+    def style(self, value: NoteStyle):
+        self._save_required |= self._style != value
+        self._style = value
 
     @position.setter
     def position(self, value: Position):
@@ -83,19 +122,20 @@ class Note:
 
         self._save_required |= is_changed
 
+    def set_callbacks(self, on_save: Optional[Callable]):
+        self._on_save_cb = on_save
+
     def save(self) -> Any:
         if self._save_required and self._on_save_cb:
             value = self._on_save_cb()
             return value
 
-    def set_callbacks(self, on_save: Optional[Callable]):
-        self._on_save_cb = on_save
-
     def to_dict(self) -> Dict[str, Any]:
         note_dict = {
             "uuid": self._uuid,
-            "pinmode": self._pinmode.name,
             "content": self._content,
+            "pinmode": self._pinmode.name,
+            "style": self._style.to_dict(),
             "position": None if self._position is None else tuple(self._position),
             "size": None if self._size is None else tuple(self._size)
         }
@@ -108,6 +148,7 @@ class Note:
             uuid=data["uuid"],
             content=data["content"],
             pinmode=NotePinMode[data["pinmode"]],
+            style=NoteStyle.from_dict(data["style"]),
             position=_ if (_ := data["position"]) is None else Position(*_),
             size=_ if (_ := data["size"]) is None else Size(*_), 
             save_required=False
@@ -117,10 +158,17 @@ class Note:
 
     @classmethod
     def new(cls):
+        # TODO Make default values not hardcoded here!
         note = cls(
             uuid=str(uuid4()),
             content="",
             pinmode=NotePinMode.NONE,
+            style=NoteStyle(
+                background_color="pink",
+                font_family="inherit",
+                font_size="inherit",
+                text_color="black",
+            ),
             save_required=True
         )
 

--- a/takenote/resources/css/__init__.py
+++ b/takenote/resources/css/__init__.py
@@ -4,4 +4,5 @@ from takenote.resources.base_resource import BaseResource, resource_library
 @resource_library(__package__)
 class CSSResource(BaseResource):
 
-    NOTE_STYLE = 'note.css'
+    NOTE_STYLE = "note.css"
+    TEMPLATE_NOTE_STYLE = "note-template.css.tmp"

--- a/takenote/resources/css/note-template.css.tmp
+++ b/takenote/resources/css/note-template.css.tmp
@@ -1,0 +1,24 @@
+window, text {
+  background-color: ${background_color};
+  font-family: ${font_family};
+  font-size: ${font_size};
+  color: ${text_color};
+  caret-color: ${text_color};
+}
+
+button {
+  background-image: none;
+  border-color: transparent;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+button:hover {
+  background-color: rgba(0,0,0,0.2);
+  background-blend-mode: multiply;
+}
+
+button:hover:active {
+  background-color: rgba(0,0,0,0.4);
+  background-blend-mode: multiply;
+}

--- a/takenote/resources/css/note.css
+++ b/takenote/resources/css/note.css
@@ -5,8 +5,12 @@ You can temporarily disable this custom CSS by clicking on the “Pause” butto
 Changes are applied instantly and globally, for the whole application.
 */
 
-window, textview, text {
+window, text {
   background-color: yellow;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  caret-color: darkslategray;
 }
 
 button {

--- a/takenote/ui/note/note_handler.py
+++ b/takenote/ui/note/note_handler.py
@@ -95,16 +95,17 @@ class NoteHandler:
     def attach_ui(notes: NotesCollection, note_uuid: str) -> NoteUI:
         builder = Gtk.Builder.new_from_file(UIResource.NOTE_WINDOW.get_filename())
 
+        note = notes.get_note(note_uuid)
+        css_string = note._style.fill_css_template(
+            CSSResource.TEMPLATE_NOTE_STYLE.get_filename())
+
         style_provider = Gtk.CssProvider.new()
-        style_provider.load_from_path(CSSResource.NOTE_STYLE.get_filename())
+        style_provider.load_from_data(css_string.encode("utf-8"))
         ui = NoteUI.from_builder(builder)
         ui.set_style(style_provider)
-
-        note = notes.get_note(note_uuid)
         notes.set_note_ui(note.uuid, ui)
 
         handler = NoteHandler(ui, notes, note.uuid)
-
         builder.connect_signals(handler)
 
         return ui


### PR DESCRIPTION
Add css styling support for:

- text color;
- font size;
- font family;
- note background color;

Note:
Css editing was done using `string.Template` thus this approach should be changed in the future by using something like `tinycss2`+`cssselect2`.

closes #27 